### PR TITLE
Initial error message scaffolding

### DIFF
--- a/Source/DolphinProcess/DolphinAccessor.cpp
+++ b/Source/DolphinProcess/DolphinAccessor.cpp
@@ -67,6 +67,11 @@ DolphinAccessor::DolphinStatus DolphinAccessor::getStatus()
   return m_status;
 }
 
+std::string DolphinAccessor::getLastErrorMessage()
+{
+  return m_instance->getLastErrorMessage();
+}
+
 bool DolphinAccessor::readFromRAM(const u32 offset, char* buffer, const size_t size,
                                   const bool withBSwap)
 {

--- a/Source/DolphinProcess/DolphinAccessor.h
+++ b/Source/DolphinProcess/DolphinAccessor.h
@@ -28,6 +28,7 @@ public:
   static int getPID();
   static u64 getEmuRAMAddressStart();
   static DolphinStatus getStatus();
+  static std::string getLastErrorMessage();
   static bool isARAMAccessible();
   static u64 getARAMAddressStart();
   static bool isMEM2Present();

--- a/Source/DolphinProcess/IDolphinProcess.h
+++ b/Source/DolphinProcess/IDolphinProcess.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 #include "../Common/CommonTypes.h"
 
@@ -19,6 +20,7 @@ public:
                           const bool withBSwap) = 0;
 
   int getPID() const { return m_PID; };
+  std::string getLastErrorMessage() const { return m_error; };
   u64 getEmuRAMAddressStart() const { return m_emuRAMAddressStart; };
   bool isMEM2Present() const { return m_MEM2Present; };
   bool isARAMAccessible() const { return m_ARAMAccessible; };
@@ -33,6 +35,7 @@ public:
 
 protected:
   int m_PID = -1;
+  std::string m_error = "";
   u64 m_emuRAMAddressStart = 0;
   u64 m_emuARAMAdressStart = 0;
   u64 m_MEM2AddressStart = 0;

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -9,7 +9,6 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fstream>
-#include <format>
 #include <iostream>
 #include <sstream>
 #include <string>

--- a/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
+++ b/Source/DolphinProcess/Linux/LinuxDolphinProcess.cpp
@@ -7,7 +7,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <dirent.h>
+#include <errno.h>
 #include <fstream>
+#include <format>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -167,8 +169,16 @@ bool LinuxDolphinProcess::readFromRAM(const u32 offset, char* buffer, const size
   remote.iov_len = size;
 
   nread = process_vm_readv(m_PID, &local, 1, &remote, 1, 0);
-  if (nread != size)
+  if (nread != size) {
+    std::stringstream err_msg;
+    if (nread == -1) {
+      err_msg << "got OS error " << errno << ": " << strerror(errno); 
+    } else {
+      err_msg << "expected " << size << " bytes, got " << nread;
+    }
+    m_error = err_msg.str();
     return false;
+  }
 
   if (withBSwap)
   {
@@ -268,10 +278,20 @@ bool LinuxDolphinProcess::writeToRAM(const u32 offset, const char* buffer, const
 
   nwrote = process_vm_writev(m_PID, &local, 1, &remote, 1, 0);
   delete[] bufferCopy;
-  if (nwrote != size)
+  if (nwrote != size) {
+    std::stringstream err_msg;
+    if (nwrote == -1) {
+      err_msg << "got OS error " << errno << ": " << strerror(errno); 
+    } else {
+      err_msg << "expected " << size << " bytes, wrote " << nwrote;
+    }
+    m_error = err_msg.str();
     return false;
+  }
 
   return true;
 }
+
 }  // namespace DolphinComm
 #endif
+

--- a/_dolphin_memory_engine.pyx
+++ b/_dolphin_memory_engine.pyx
@@ -58,10 +58,13 @@ cdef extern from "DolphinProcess/DolphinAccessor.h" namespace "DolphinComm":
 
         @staticmethod
         int getPID()
-        
+
         @staticmethod
         DolphinStatus getStatus()
 
+        @staticmethod
+        string getLastErrorMessage()
+        
         @staticmethod
         c_bool isValidConsoleAddress(uint32_t)
 
@@ -153,7 +156,7 @@ def follow_pointers(console_address: int, pointer_offsets: List[int]) -> int:
             else:
                 raise RuntimeError(f"Address {real_console_address} is not valid")
         else:
-            raise RuntimeError(f"Could not read memory at {real_console_address}")
+            raise RuntimeError(f"Could not read memory at {real_console_address}: {}", DolphinAccessor.getLastErrorMessage())
 
     return real_console_address
 
@@ -161,7 +164,7 @@ def follow_pointers(console_address: int, pointer_offsets: List[int]) -> int:
 cdef _read_memory(console_address, char* memory_buffer, int size):
     assert_hooked()
     if not DolphinAccessor.readFromRAM(dolphinAddrToOffset(console_address, DolphinAccessor.isARAMAccessible()), memory_buffer, size, True):
-        raise RuntimeError(f"Could not read memory at {console_address}")
+        raise RuntimeError(f"Could not read memory at {console_address}: {}", DolphinAccessor.getLastErrorMessage())
 
 
 def read_byte(console_address: int) -> int:
@@ -191,14 +194,14 @@ def read_double(console_address: int) -> double:
 def read_bytes(console_address: int, size: int) -> bytes:
     memory = bytearray(size)
     if not DolphinAccessor.readFromRAM(dolphinAddrToOffset(console_address, DolphinAccessor.isARAMAccessible()), memory, size, False):
-        raise RuntimeError(f"Could not read memory at {console_address}")
+        raise RuntimeError(f"Could not read memory at {console_address}: {}", DolphinAccessor.getLastErrorMessage())
     return bytes(memory)
 
 
 cdef _write_memory(console_address, char* memory_buffer, int size):
     assert_hooked()
     if not DolphinAccessor.writeToRAM(dolphinAddrToOffset(console_address, DolphinAccessor.isARAMAccessible()), memory_buffer, size, True):
-        raise RuntimeError(f"Could not write memory at {console_address}")
+        raise RuntimeError(f"Could not write memory at {console_address}: {}", DolphinAccessor.getLastErrorMessage())
 
 
 def write_byte(console_address: int, value: int):
@@ -228,4 +231,4 @@ def write_double(console_address: int, value: double):
 def write_bytes(console_address: int, memory: bytes):
     assert_hooked()
     if not DolphinAccessor.writeToRAM(dolphinAddrToOffset(console_address, DolphinAccessor.isARAMAccessible()), memory, len(memory), False):
-        raise RuntimeError(f"Could not write memory at {console_address}")
+        raise RuntimeError(f"Could not write memory at {console_address}: {}", DolphinAccessor.getLastErrorMessage())

--- a/_dolphin_memory_engine.pyx
+++ b/_dolphin_memory_engine.pyx
@@ -1,5 +1,4 @@
 from typing import List
-
 from libc.stdint cimport uint8_t, uint32_t, uint64_t
 from libcpp cimport bool as c_bool
 from libcpp.string cimport string
@@ -156,7 +155,7 @@ def follow_pointers(console_address: int, pointer_offsets: List[int]) -> int:
             else:
                 raise RuntimeError(f"Address {real_console_address} is not valid")
         else:
-            raise RuntimeError(f"Could not read memory at {real_console_address}: {}", DolphinAccessor.getLastErrorMessage())
+            raise RuntimeError(f"Could not read memory at {real_console_address}: {DolphinAccessor.getLastErrorMessage()}")
 
     return real_console_address
 
@@ -164,7 +163,7 @@ def follow_pointers(console_address: int, pointer_offsets: List[int]) -> int:
 cdef _read_memory(console_address, char* memory_buffer, int size):
     assert_hooked()
     if not DolphinAccessor.readFromRAM(dolphinAddrToOffset(console_address, DolphinAccessor.isARAMAccessible()), memory_buffer, size, True):
-        raise RuntimeError(f"Could not read memory at {console_address}: {}", DolphinAccessor.getLastErrorMessage())
+        raise RuntimeError(f"Could not read memory at {console_address}: {DolphinAccessor.getLastErrorMessage()}")
 
 
 def read_byte(console_address: int) -> int:
@@ -194,14 +193,14 @@ def read_double(console_address: int) -> double:
 def read_bytes(console_address: int, size: int) -> bytes:
     memory = bytearray(size)
     if not DolphinAccessor.readFromRAM(dolphinAddrToOffset(console_address, DolphinAccessor.isARAMAccessible()), memory, size, False):
-        raise RuntimeError(f"Could not read memory at {console_address}: {}", DolphinAccessor.getLastErrorMessage())
+        raise RuntimeError(f"Could not read memory at {console_address}: {DolphinAccessor.getLastErrorMessage()}")
     return bytes(memory)
 
 
 cdef _write_memory(console_address, char* memory_buffer, int size):
     assert_hooked()
     if not DolphinAccessor.writeToRAM(dolphinAddrToOffset(console_address, DolphinAccessor.isARAMAccessible()), memory_buffer, size, True):
-        raise RuntimeError(f"Could not write memory at {console_address}: {}", DolphinAccessor.getLastErrorMessage())
+        raise RuntimeError(f"Could not write memory at {console_address}: {DolphinAccessor.getLastErrorMessage()}")
 
 
 def write_byte(console_address: int, value: int):
@@ -231,4 +230,4 @@ def write_double(console_address: int, value: double):
 def write_bytes(console_address: int, memory: bytes):
     assert_hooked()
     if not DolphinAccessor.writeToRAM(dolphinAddrToOffset(console_address, DolphinAccessor.isARAMAccessible()), memory, len(memory), False):
-        raise RuntimeError(f"Could not write memory at {console_address}: {}", DolphinAccessor.getLastErrorMessage())
+        raise RuntimeError(f"Could not write memory at {console_address}: {DolphinAccessor.getLastErrorMessage()}")


### PR DESCRIPTION
My attempt at a solution to #196. Provides an error message variable that can be set by implementers of `IDolphinProcess` so that more information can be returned to the user when errors occur.