### PR TITLE
Adding macOS Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,12 @@ venv.bak/
 
 # Project
 /python_src/dolphin_memory_engine/version.py
+
+# macOS system files
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+.Spotlight-V100
+.Trashes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Binary wheels are available on pypi for Python 3.8 to 3.12. Use `python -m pip i
 
 
 ## System requirements
-Any x86_64 based system should work, however, Mac OS is _not_ supported. Additionally, 32-bit x86 based systems are unsupported since Dolphin dropped their support.
+Any x86_64 based system should work. To run on macOS (ARM and x86_64), a custom code signature is required. Instructions can be found on the Dolphin Memory Engine repository [here](https://github.com/aldelaro5/dolphin-memory-engine#macos-code-signing). Additionally, 32-bit x86 based systems are unsupported since Dolphin dropped their support.
 
 You need to have Dolphin running ***and*** _have the emulation started_ for this program to be useful. As such, the system must meet Dolphin's [system requirements](https://github.com/dolphin-emu/dolphin#system-requirements). Additionally, at least 250 MB of free memory is required.
 


### PR DESCRIPTION
Hello,

I discovered that following the macOS code signing instructions for [Dolphin Memory Engine](https://github.com/aldelaro5/dolphin-memory-engine#macos-code-signing) allows `py-dolphin-memory-engine` to function correctly on macOS as well. I confirmed this by successfully setting up and playing an Archipelago randomizer version of Super Mario Sunshine, which requires `py-dolphin-memory-engine` to function.

I included the `MacSetup.sh` file required to patch Dolphin and updated the readme with the same instructions that DME uses.

Please let me know if you have any questions or concerns. I am a very new developer and new to GitHub overall so if I didn't do something correctly please let me know.